### PR TITLE
Add FastAPI wrapper and update Docker Compose for Ollama integration

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,9 @@
-localhost:{$LLM_CONTAINER_PORT} {
+localhost:3334 {
     tls internal
     reverse_proxy llm-container:2242
 }
 
-127.0.0.1:{$LLM_CONTAINER_PORT} {
+127.0.0.1:3334 {
     tls internal
     reverse_proxy llm-container:2242
 }

--- a/Dockerfile.wrapper
+++ b/Dockerfile.wrapper
@@ -1,0 +1,11 @@
+# Use the official Python image
+FROM python:3.9-slim
+
+# Install FastAPI, Uvicorn, and requests
+RUN pip install fastapi uvicorn requests
+
+# Copy the FastAPI app to the container
+COPY ./api_wrapper.py api_wrapper.py
+
+# Expose FastAPI port
+EXPOSE 5000

--- a/api_wrapper.py
+++ b/api_wrapper.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI, Request, HTTPException, Depends
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import requests
+import os
+import secrets
+
+# Initialize the FastAPI app
+app = FastAPI()
+
+# Function to generate a secure API key
+def generate_api_key():
+    return secrets.token_urlsafe(32)
+
+# Define the API key for authentication
+API_KEY = os.getenv("SESSION_API_KEY", generate_api_key())
+
+print("\n" + "="*50)
+print(" " * 5 + "⚠️ IMPORTANT: API Key Information ⚠️" + " " * 5)
+print("="*50)
+print("\n" + " " * 3 + f" Session API Key: {API_KEY} " + "\n")
+print("="*50)
+print("\nNOTE:")
+print("- Do not share your API key publicly.")
+print("- Avoid committing API keys in code repositories.")
+print("- If exposed, reset and replace it immediately.\n")
+print("="*50 + "\n")
+
+bearer_scheme = HTTPBearer()
+
+# Set the URL of the internal Ollama API (using the service name defined in docker-compose.yml)
+OLLAMA_URL = "http://ollama:11434"  # Docker will resolve "ollama" to the Ollama container's IP
+
+
+# Function to retrieve and validate the API key from the request headers
+def get_api_key(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> str:
+    global API_KEY
+    token = credentials.credentials
+    if token == API_KEY:
+        return token
+    raise HTTPException(
+        status_code=401,
+        detail="Invalid or missing Bearer Token",
+    )
+
+# Function to check and retrieve the API key from the environment variables
+def check_api_key():
+    api_key = os.getenv('SESSION_API_KEY')
+    if not api_key:
+        # If not found, generate a new one and store it in environment variables
+        api_key = generate_api_key()
+        os.environ['SESSION_API_KEY'] = api_key
+    return api_key
+
+# Function to get the client's IP address from request headers
+def get_ip_from_headers(request: Request):
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0]
+    return request.client.host
+
+# Define the health endpoint without authentication
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+# Define proxy endpoint with authentication dependency
+@app.api_route("/{path:path}", methods=["GET", "POST"], dependencies=[Depends(get_api_key)])
+async def proxy_request(path: str, request: Request):
+    try:
+        # Prepare headers and body based on the request method
+        headers = dict(request.headers)
+        if request.method == "GET":
+            response = requests.get(f"{OLLAMA_URL}/{path}", headers=headers, params=request.query_params)
+            print(response)
+        elif request.method == "POST":
+            body = await request.json()
+            response = requests.post(f"{OLLAMA_URL}/{path}", headers=headers, json=body)
+            print(response.json())
+
+        # Return the response from the Ollama API
+        return JSONResponse(content=response.json(), status_code=response.status_code)
+    except Exception as e:
+        return JSONResponse(content={"error": str(e)}, status_code=500)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
 services:
-  # Define the services that will be run by Docker Compose
-  llm-container:
-    # Service for the LLM container
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    volumes:
+      - ./ollama-data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - OLLAMA_CONCURRENT_REQUESTS=2
+      - OLLAMA_QUEUE_ENABLED=true
+    networks:
+      - ollama_network
     deploy:
-      # Resource allocation settings
       resources:
         reservations:
-          # Device reservations
           devices:
             - driver: nvidia
               count: all
-              capabilities:
-                - gpu
+              capabilities: [gpu]
+
+  fastapi-wrapper:
     build:
-      # Build context and Dockerfile for the LLM container
       context: .
-      dockerfile: Dockerfile.llm-cont
-    user: "1000:1000" # Set the user to '1000:1000'
-    # Ensure the container runs with the specified user and group ID
-    volumes:
-      # Mount the local models directory to the container's /models directory
-      - ./models:/models
-    networks:
-      # Attach the container to the llm-network
-      - llm-network
-    ipc: host
-    # Use the host's IPC namespace for inter-process communication
+      dockerfile: Dockerfile.wrapper
+    container_name: fastapi-wrapper
+    restart: unless-stopped
     environment:
-      - MODEL_NAME=${MODEL_NAME:-/models/gemma-2-2b-it}
-      - HF_TOKEN=${HF_TOKEN}
-      - CHAT_TEMPLATE=${CHAT_TEMPLATE:-}
-    # Use command-line string concatenation for conditional command
-    # Only pass a chat template if one is provided
-    command: >
-      --model ${MODEL_NAME:-/models/gemma-2-2b-it}
-      ${CHAT_TEMPLATE:+--chat-template ${CHAT_TEMPLATE}}
-    # Command to run when the container starts
+      - PYTHONUNBUFFERED=1
+    # - API_KEY=your_secret_api_key
+    ports:
+      - "5000:5000"
+    depends_on:
+      - ollama
+    command: "uvicorn api_wrapper:app --host 0.0.0.0 --port 5000 --log-level debug"
+    networks:
+      - ollama_network
+
   caddy:
     # Service for the Caddy container
-    container_name: caddy-llm-container # Name of the container
+    container_name: caddy-ollama # Name of the container
     user: "1000:1000" # Set the user to '1000:1000'
     build:
       # Build context and Dockerfile for the Caddy container
@@ -49,15 +51,11 @@ services:
       - LLM_CONTAINER_PORT=${LLM_CONTAINER_PORT:-3334}
     ports:
       # Map port 3334 on the host to port 3334 in the container
-      - ${LLM_CONTAINER_PORT:-3334}:${LLM_CONTAINER_PORT:-3334}
+      - ${LLM_CONTAINER_PORT:-3334}:5000
     networks:
       # Attach the container to the llm-network
-      - llm-network
-    depends_on:
-      # Ensure the Caddy container starts after the LLM container
-      - llm-container
+      - ollama_network
 
 networks:
-  # Define the network for the services
-  llm-network:
+  ollama_network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,12 @@ services:
     environment:
       - MODEL_NAME=${MODEL_NAME:-/models/gemma-2-2b-it}
       - HF_TOKEN=${HF_TOKEN}
-    command: --model ${MODEL_NAME:-/models/gemma-2-2b-it}
+      - CHAT_TEMPLATE=${CHAT_TEMPLATE:-}
+    # Use command-line string concatenation for conditional command
+    # Only pass a chat template if one is provided
+    command: >
+      --model ${MODEL_NAME:-/models/gemma-2-2b-it}
+      ${CHAT_TEMPLATE:+--chat-template ${CHAT_TEMPLATE}}
     # Command to run when the container starts
   caddy:
     # Service for the Caddy container


### PR DESCRIPTION
## Summary by Sourcery

Revamp the Docker Compose setup by introducing a new FastAPI application as a proxy for the Ollama service, replacing the previous 'llm-container'. Update the Caddy service configuration to align with the new network and service changes, and add a Dockerfile for the FastAPI wrapper.

New Features:
- Introduce a new FastAPI application to act as a proxy with authentication for the Ollama service.

Enhancements:
- Replace the 'llm-container' service with 'ollama' and 'fastapi-wrapper' services in the Docker Compose configuration.
- Update the Caddy service to connect to the new 'ollama_network' and adjust port mappings.

Build:
- Add a new Dockerfile for the FastAPI wrapper service.