### PR TITLE
Load model on start

### DIFF
--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -2,7 +2,7 @@
 FROM caddy:2.8.4
 
 # Create a group with GID 1000 and a user with UID 1000
-RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
+RUN addgroup -g 1000 appgroup && adduser -u 1000 -G appgroup -D -s /bin/sh appuser
 
 # Set permissions for non root user in directories we will need
 RUN mkdir -p /data && chown -R 1000:1000 /data

--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -1,6 +1,8 @@
 # Use the official Caddy image as the base image
 FROM caddy:2.8.4
 
+# Create a group with GID 1000 and a user with UID 1000
+RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
 
 # Set permissions for non root user in directories we will need
 RUN mkdir -p /data && chown -R 1000:1000 /data

--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,6 +1,7 @@
 FROM ollama/ollama:latest
 
-RUN adduser --uid 1000 --disabled-password --gecos "" appuser
+# Create a group with GID 1000 and a user with UID 1000
+RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
 
 # set permission for non root to ollama directory
 RUN mkdir -p /.ollama && chown -R 1000:1000 /.ollama

--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,4 +1,6 @@
 FROM ollama/ollama:latest
 
+RUN adduser --uid 1000 --disabled-password --gecos "" appuser
+
 # set permission for non root to ollama directory
 RUN mkdir -p /.ollama && chown -R 1000:1000 /.ollama

--- a/Dockerfile.wrapper
+++ b/Dockerfile.wrapper
@@ -1,6 +1,9 @@
 # Use the official Python image
 FROM python:3.9-slim
 
+# Create a group with GID 1000 and a user with UID 1000
+RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
+
 #Set the working dir
 WORKDIR /app
 

--- a/api_wrapper.py
+++ b/api_wrapper.py
@@ -69,7 +69,7 @@ async def rate_limit_middleware(request, call_next):
         )
 
 @app.api_route("/{path:path}", methods=["GET", "POST"], dependencies=[Depends(API_KEY_MANAGER.verify_api_key)])
-@limiter.limit("1/second")
+@limiter.limit("10/second")
 async def proxy_request(path: str, request: Request):
     """
     Proxy endpoint that forwards requests to the Ollama API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: . # Build context is the current directory
       dockerfile: Dockerfile.ollama # Use the Ollama-specific Dockerfile
-    user: "1000:1000" # Run as user:group 1000:1000
+    user: "appuser:appgroup" # Run as user:group 1000:1000
     container_name: ollama # Set a specific name for the container
     restart: unless-stopped # Automatically restart container unless manually stopped
     volumes:
@@ -31,7 +31,7 @@ services:
     build:
       context: . # Build context is the current directory
       dockerfile: Dockerfile.wrapper # Use the wrapper-specific Dockerfile
-    user: "1000:1000" # Run as user:group 1000:1000
+    user: "appuser:appgroup" # Run as user:group 1000:1000
     container_name: authentication-ollama # Set container name
     restart: unless-stopped # Automatic restart policy
     environment:
@@ -46,7 +46,7 @@ services:
   # Caddy service configuration - Reverse proxy and HTTPS
   caddy:
     container_name: caddy-ollama # Container name for Caddy service
-    user: "1000:1000" # Run as user:group 1000:1000
+    user: "appuser:appgroup" # Run as user:group 1000:1000
     build:
       context: . # Build context is current directory
       dockerfile: Dockerfile.caddy # Use Caddy-specific Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
   # Caddy service configuration - Reverse proxy and HTTPS
   caddy:
     container_name: caddy-ollama # Container name for Caddy service
+    restart: unless-stopped # Automatic restart policy
     user: "appuser:appgroup" # Run as user:group 1000:1000
     build:
       context: . # Build context is current directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,15 @@ services:
     user: "1000:1000" # Run as user:group 1000:1000
     container_name: ollama # Set a specific name for the container
     restart: unless-stopped # Automatically restart container unless manually stopped
+    volumes:
+        - ./ollama-entrypoint.sh:/ollama-entrypoint.sh
     environment:
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all} # Configure GPU visibility, defaults to all
       - OLLAMA_CONCURRENT_REQUESTS=${OLLAMA_CONCURRENT_REQUESTS:-1} # Number of concurrent requests, defaults to 1
       - OLLAMA_QUEUE_ENABLED=${OLLAMA_QUEUE_ENABLED:-true} # Enable request queuing, defaults to true
     networks:
       - ollama_network # Connect to the ollama_network bridge network
+    entrypoint: ["/usr/bin/bash", "/ollama-entrypoint.sh"]
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
         - ./ollama-entrypoint.sh:/ollama-entrypoint.sh
     environment:
+      - OLLAMA_KEEP_ALIVE=-1 # Keep the service running indefinitely
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all} # Configure GPU visibility, defaults to all
       - OLLAMA_CONCURRENT_REQUESTS=${OLLAMA_CONCURRENT_REQUESTS:-1} # Number of concurrent requests, defaults to 1
       - OLLAMA_QUEUE_ENABLED=${OLLAMA_QUEUE_ENABLED:-true} # Enable request queuing, defaults to true

--- a/ollama-entrypoint.sh
+++ b/ollama-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Start Ollama in the background.
+/bin/ollama serve &
+# Record Process ID.
+pid=$!
+
+# Pause for Ollama to start.
+sleep 5
+
+echo "🔴 Pulling gemma2:2b-instruct-q8_0 model..."
+ollama pull gemma2:2b-instruct-q8_0
+echo "🟢 Successfully pulled gemma2:2b-instruct-q8_0"
+
+echo "🔴 Running gemma2:2b-instruct-q8_0 model..."
+ollama run gemma2:2b-instruct-q8_0
+echo "🟢 Successfully ran gemma2:2b-instruct-q8_0"
+
+# Wait for Ollama process to finish.
+wait $pid

--- a/ollama-entrypoint.sh
+++ b/ollama-entrypoint.sh
@@ -8,13 +8,23 @@ pid=$!
 # Pause for Ollama to start.
 sleep 5
 
+# Pull the model with error handling
 echo "🔴 Pulling gemma2:2b-instruct-q8_0 model..."
-ollama pull gemma2:2b-instruct-q8_0
-echo "🟢 Successfully pulled gemma2:2b-instruct-q8_0"
+if ollama pull gemma2:2b-instruct-q8_0; then
+    echo "🟢 Successfully pulled gemma2:2b-instruct-q8_0"
+else
+    echo "🔴 Failed to pull gemma2:2b-instruct-q8_0"
+    exit 1
+fi
 
+# Run the model with error handling
 echo "🔴 Running gemma2:2b-instruct-q8_0 model..."
-ollama run gemma2:2b-instruct-q8_0
-echo "🟢 Successfully ran gemma2:2b-instruct-q8_0"
+if ollama run gemma2:2b-instruct-q8_0; then
+    echo "🟢 Successfully ran gemma2:2b-instruct-q8_0"
+else
+    echo "🔴 Failed to run gemma2:2b-instruct-q8_0"
+    exit 1
+fi
 
 # Wait for Ollama process to finish.
 wait $pid


### PR DESCRIPTION
### Issue
- #10 
- #12 
- #9  
- #11

## Summary by Sourcery

Load the 'gemma2:2b-instruct-q8_0' model on startup by adding an entrypoint script in the Docker setup. Update the Docker Compose configuration to change the user and set the entrypoint. Increase the API request rate limit to improve performance.

New Features:
- Introduce a new entrypoint script to automatically pull and run the 'gemma2:2b-instruct-q8_0' model on startup.

Enhancements:
- Increase the rate limit for API requests from 1 per second to 10 per second.

Build:
- Modify Docker Compose configuration to change the user running the services from '1000:1000' to 'appuser:appgroup'.
- Add a volume mapping for the new entrypoint script in the Docker Compose configuration.
- Set an entrypoint in the Docker Compose configuration to execute the new entrypoint script.