### PR TITLE
set eof of scripts to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add .gitattributes file to enforce LF line endings for scripts.