### PR TITLE
refactor(proxy): Refactored proxy to use httpx async client.

### DIFF
--- a/api_wrapper.py
+++ b/api_wrapper.py
@@ -308,8 +308,8 @@ class RequestHandler:
             # Shouldn't reach here
             raise HTTPException(status_code=500, detail="Unexpected state")
             
-        except asyncio.CancelledError:
-            raise HTTPException(status_code=499, detail="Request cancelled")
+        except asyncio.CancelledError as e:
+            raise HTTPException(status_code=499, detail="Request cancelled") from e
         except httpx.ReadError as e:
             logger.exception(f"HTTP Read error: {e}")
             return JSONResponse(
@@ -321,8 +321,8 @@ class RequestHandler:
                 content={"error": "Request to Ollama service timed out"},
                 status_code=504
             )
-        except HTTPException:
-            raise
+        except HTTPException as e:
+            raise e
         except Exception as e:
             logger.exception(f"Unexpected error: {e}")
             return JSONResponse(

--- a/api_wrapper.py
+++ b/api_wrapper.py
@@ -224,7 +224,7 @@ class RequestHandler:
         elif self.request.method == "POST":
             body = await self.request.json()
             return await self.client.post(
-                target_url,
+                f"{OLLAMA_URL}/{self.path}",
                 headers=headers,
                 json=body
             )

--- a/api_wrapper.py
+++ b/api_wrapper.py
@@ -93,7 +93,8 @@ class RequestHandler:
         self.disconnect_event = asyncio.Event()
     
     async def __aenter__(self):
-        self.client = httpx.AsyncClient(timeout=30.0)
+        timeout = httpx.Timeout(timeout=180.0, connect=10.0, read=180.0, write=180.0, pool=180.0)
+        self.client = httpx.AsyncClient(timeout=timeout)
         return self
     
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -140,7 +141,7 @@ class RequestHandler:
         elif self.request.method == "POST":
             body = await self.request.json()
             return await self.client.post(
-                f"{OLLAMA_URL}/{self.path}",
+                target_url,
                 headers=headers,
                 json=body
             )


### PR DESCRIPTION
Async client allows us to close the connection mid request and cancel the inferencing on the ollama end.

Still backwards compatible with older clients.

## Summary by Sourcery

Refactor the proxy endpoint to use an async httpx client and manage request lifecycle with connection cancellation support.

New Features:
- Support mid-request cancellation and connection closure to stop inference on the Ollama side

Enhancements:
- Refactor proxy forwarding logic into a RequestHandler with httpx.AsyncClient
- Introduce concurrent tasks to monitor client disconnect events and cancel in-flight requests
- Implement detailed error handling for read errors, timeouts, and client disconnects with appropriate HTTP status codes